### PR TITLE
When failure-details is specified only attach failure details block for Slack if there were failures

### DIFF
--- a/src/targets/slack.js
+++ b/src/targets/slack.js
@@ -81,7 +81,10 @@ function setSuiteBlock({ result, target, payload }) {
         payload.blocks.push(getSuiteSummary({ target, suite }));
       }
       if (target.inputs.include_failure_details) {
-        payload.blocks.push(getFailureDetails(suite));
+        // Only attach failure details block if there were failures
+        if (result.failed > 0 ) {
+          payload.blocks.push(getFailureDetails(suite));
+        }
       }
     }
   }

--- a/src/targets/slack.js
+++ b/src/targets/slack.js
@@ -82,7 +82,7 @@ function setSuiteBlock({ result, target, payload }) {
       }
       if (target.inputs.include_failure_details) {
         // Only attach failure details block if there were failures
-        if (result.failed > 0 ) {
+        if (suite.failed > 0 ) {
           payload.blocks.push(getFailureDetails(suite));
         }
       }


### PR DESCRIPTION
Slack throws a `Bad Request` error if a section block with empty markdown is sent.  This causes the publish to fail if `failure-details` is specified and all tests passed. 

```
StatusCodeError: 400 - invalid_attachments
    at Object.reject ([...]/node_modules/phin-retry/src/index.js:184:11)
    at Object.__fetch ([...]/node_modules/phin-retry/src/index.js:268:21)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.run ([...]/node_modules/test-results-reporter/src/targets/index.js:30:5)
    at async Object.run ([...]/node_modules/test-results-reporter/src/commands/publish.js:20:9) {
  statusCode: 400,
  statusMessage: 'Bad Request',
  body: 'invalid_attachments'
}
```

Fix verifies there are failures before calling `getFailureDetails()` to add the details block. 

Verified that when `failure-details` is specified the message is sent successfully to Slack for both suites with failures and suites will all tests passing. 

Verified that the failure details are included in the message when `failure-details` is specified and there are failing tests