### PR TITLE
fix ReportPortal history urls

### DIFF
--- a/src/extensions/report-portal-history.js
+++ b/src/extensions/report-portal-history.js
@@ -28,7 +28,7 @@ function getSymbols({ target, extension, launches }) {
   const symbols = [];
   for (let i = 0; i < launches.length; i++) {
     const launch = launches[i];
-    const launch_url = `${extension.inputs.url}/ui/#${extension.inputs.project}/launches/all/${extension.inputs.link_history_via}`;
+    const launch_url = `${extension.inputs.url}/ui/#${extension.inputs.project}/launches/all/${launch[extension.inputs.link_history_via]}`;
     let current_symbol = '⚠️';
     if (launch.status === 'PASSED') {
       current_symbol = '✅'; 

--- a/src/extensions/report-portal-history.js
+++ b/src/extensions/report-portal-history.js
@@ -24,20 +24,11 @@ async function getLaunchHistory(extension) {
   return [];
 }
 
-function setLinkHistoryViaProperty(extension) {
-  var linkHistoryVia = "uuid";
-  if( extension.inputs.link_history_via && extension.inputs.link_history_via != '') {
-    linkHistoryVia = extension.inputs.link_history_via;
-  }
-  return linkHistoryVia;
-}
-
 function getSymbols({ target, extension, launches }) {
   const symbols = [];
   for (let i = 0; i < launches.length; i++) {
     const launch = launches[i];
-    eval("var linkHistoryVia = launch." + setLinkHistoryViaProperty(extension));
-    const launch_url = `${extension.inputs.url}/ui/#${extension.inputs.project}/launches/all/${linkHistoryVia}`;
+    const launch_url = `${extension.inputs.url}/ui/#${extension.inputs.project}/launches/all/${extension.inputs.link_history_via}`;
     let current_symbol = '⚠️';
     if (launch.status === 'PASSED') {
       current_symbol = '✅'; 
@@ -104,6 +95,7 @@ async function run({ extension, target, payload }) {
 const default_inputs = {
   history_depth: 5,
   title: 'Last Runs',
+  link_history_via: 'uuid'
 }
 
 const default_inputs_teams = {

--- a/src/extensions/report-portal-history.js
+++ b/src/extensions/report-portal-history.js
@@ -24,11 +24,20 @@ async function getLaunchHistory(extension) {
   return [];
 }
 
+function setLinkHistoryViaProperty(extension) {
+  var linkHistoryVia = "uuid";
+  if( extension.inputs.link_history_via && extension.inputs.link_history_via != '') {
+    linkHistoryVia = extension.inputs.link_history_via;
+  }
+  return linkHistoryVia;
+}
+
 function getSymbols({ target, extension, launches }) {
   const symbols = [];
   for (let i = 0; i < launches.length; i++) {
     const launch = launches[i];
-    const launch_url = `${extension.inputs.url}/ui/#${extension.inputs.project}/launches/all/${launch.launchId}`;
+    eval("var linkHistoryVia = launch." + setLinkHistoryViaProperty(extension));
+    const launch_url = `${extension.inputs.url}/ui/#${extension.inputs.project}/launches/all/${linkHistoryVia}`;
     let current_symbol = '⚠️';
     if (launch.status === 'PASSED') {
       current_symbol = '✅'; 

--- a/src/extensions/report-portal-history.js
+++ b/src/extensions/report-portal-history.js
@@ -28,7 +28,7 @@ function getSymbols({ target, extension, launches }) {
   const symbols = [];
   for (let i = 0; i < launches.length; i++) {
     const launch = launches[i];
-    const launch_url = `${extension.inputs.url}/ui/#${extension.inputs.project}/launches/all/${launch.uuid}`;
+    const launch_url = `${extension.inputs.url}/ui/#${extension.inputs.project}/launches/all/${launch.launchId}`;
     let current_symbol = '⚠️';
     if (launch.status === 'PASSED') {
       current_symbol = '✅'; 


### PR DESCRIPTION
while using ReportPortal 5.6.0 history urls were not working using uuid attribute. 

Tested with "launchId" it's working as designed.