### PR TITLE
Closes #105

### DIFF
--- a/src/targets/slack.js
+++ b/src/targets/slack.js
@@ -117,7 +117,7 @@ function getSuiteSummary({ target, suite }) {
 }
 
 function getSuiteTitle(suite) {
-  const emoji = suite.status === 'PASS' ? '✅' : '❌';
+  const emoji = suite.status === 'PASS' ? '✅' : suite.total === suite.skipped ? '⏭️' : '❌';
   return `${emoji} ${suite.name}`;
 }
 


### PR DESCRIPTION
Added an additional icon for skipped suite. Though the suite status is set to FAIL, but it does not make sense to mark it as FAIL when no tests were run.