### PR TITLE
Support slack group name mentions

### DIFF
--- a/src/extensions/mentions.js
+++ b/src/extensions/mentions.js
@@ -34,9 +34,20 @@ function attachForTeam({ extension, payload }) {
   }
 }
 
+function formatSlackMentions({slack_uid, slack_gid}) {
+  if (slack_gid && slack_uid) {
+    throw new Error(`Error in slack extension configuration. Either slack user or group Id is allowed`);
+  }
+  if (slack_uid) {
+    return `<@${slack_uid}>`
+  }
+  const tagPrefix = ["here", "everyone", "channel"].includes(slack_gid.toLowerCase()) ? "" : "subteam^";
+  return `<!${tagPrefix}${slack_gid}>`
+}
+
 function attachForSlack({ extension, payload }) {
   const users = getUsers(extension);
-  const user_ids = users.map(user => `<@${user.slack_uid}>`);
+  const user_ids = users.map(formatSlackMentions);
   if (users.length > 0) {
     addSlackExtension({ payload, extension, text: user_ids.join(' ｜ ') });
   }

--- a/test/ext.mentions.spec.js
+++ b/test/ext.mentions.spec.js
@@ -148,6 +148,90 @@ describe('extensions - mentions', () => {
     assert.equal(mock.getInteraction(id).exercised, true);
   });
 
+  it('should mention group name in slack', async () => {
+    const id = mock.addInteraction('post test-summary with mentions group name to slack');
+    await publish({
+      config: {
+        "reports": [
+          {
+            "targets": [
+              {
+                "name": "slack",
+                "inputs": {
+                  "url": "http://localhost:9393/message"
+                },
+                "extensions": [
+                  {
+                    "name": "mentions",
+                    "inputs": {
+                      "users": [
+                        {
+                          "name": "mom",
+                          "slack_gid": "ULA15K66M"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "results": [
+              {
+                "type": "testng",
+                "files": [
+                  "test/data/testng/single-suite-failures.xml"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    });
+    assert.equal(mock.getInteraction(id).exercised, true);
+  });
+
+  it('should mention special group name in slack', async () => {
+    const id = mock.addInteraction('post test-summary with mentions special group name to slack');
+    await publish({
+      config: {
+        "reports": [
+          {
+            "targets": [
+              {
+                "name": "slack",
+                "inputs": {
+                  "url": "http://localhost:9393/message"
+                },
+                "extensions": [
+                  {
+                    "name": "mentions",
+                    "inputs": {
+                      "users": [
+                        {
+                          "name": "mom",
+                          "slack_gid": "here"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            "results": [
+              {
+                "type": "testng",
+                "files": [
+                  "test/data/testng/single-suite-failures.xml"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    });
+    assert.equal(mock.getInteraction(id).exercised, true);
+  });
+
   it('should mention users with schedule rotation in slack', async () => {
     const id = mock.addInteraction('post test-summary with mentions to slack');
     await publish({

--- a/test/mocks/slack.mock.js
+++ b/test/mocks/slack.mock.js
@@ -385,6 +385,69 @@ addInteractionHandler('post test-summary with mentions to slack', () => {
   }
 });
 
+
+addInteractionHandler('post test-summary with mentions group name to slack', () => {
+  return {
+    request: {
+      method: 'POST',
+      path: '/message',
+      body: {
+        "attachments": [
+          {
+            "color": "#DC143C",
+            "blocks": [
+              {
+                "@DATA:TEMPLATE@": "SLACK_ROOT_SINGLE_SUITE_FAILURE"
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "<!subteam^ULA15K66M>"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    response: {
+      status: 200
+    }
+  }
+});
+
+addInteractionHandler('post test-summary with mentions special group name to slack', () => {
+  return {
+    request: {
+      method: 'POST',
+      path: '/message',
+      body: {
+        "attachments": [
+          {
+            "color": "#DC143C",
+            "blocks": [
+              {
+                "@DATA:TEMPLATE@": "SLACK_ROOT_SINGLE_SUITE_FAILURE"
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "<!here>"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    response: {
+      status: 200
+    }
+  }
+});
+
 addInteractionHandler('post test-summary to slack with qc-test-summary', (ctx) => {
   return {
     request: {


### PR DESCRIPTION
Closes #164 

**Summary:**
- Support to add slack group id to mentions in test results reporter.
- A new key `slack_gid` for slack group id is added.
- Supports special mentions (to be provided in lower case only and without `@`) - `here`, `channel`, `everyone` 
- Note: for a given user, only one of either `slack_uid` or `slack_gid` is allowed.